### PR TITLE
Update LDAP.pm

### DIFF
--- a/Bugzilla/Auth/Verify/LDAP.pm
+++ b/Bugzilla/Auth/Verify/LDAP.pm
@@ -139,7 +139,7 @@ sub _bind_ldap_for_search {
     my $bind_result;
     if (Bugzilla->params->{"LDAPbinddn"}) {
         my ($LDAPbinddn,$LDAPbindpass) = 
-            split(":",Bugzilla->params->{"LDAPbinddn"});
+            split(":",Bugzilla->params->{"LDAPbinddn"},2);
         $bind_result = 
             $self->ldap->bind($LDAPbinddn, password => $LDAPbindpass);
     }


### PR DESCRIPTION
CHG: if you use a password with a colon, you cannot log into the ldap account, because split() will destroy your password. the change will limit the pieces to two, so we have part one, the username and part two the password with colon. I'm not sure, whether or not it is possible to have an username with colons...